### PR TITLE
Ignore automatically-generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+/META.yml
+/MYMETA.json
+/MYMETA.yml
+/Makefile
+/blib/
+/inc/
+/pm_to_blib


### PR DESCRIPTION
This patch ignores files which are automatically generated as part of setting up the dist and running the tests by adding their names to the `.gitignore` file.  Now, when one runs `git status` the working directory is clean.

This PR is submitted in the hope that it is helpful, so if there's anything you'd like changed, please let me know and I'll update and resubmit as necessary.