### PR TITLE
Remove trailing whitespace

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,8 +1,8 @@
 Revision history for HTML-FormFu-Model-LDAP
 0.0103  2008-10-08 12:27:00+0200
-        I hate checkboxes and everything related to them. 
+        I hate checkboxes and everything related to them.
         God damn piece of crap design.
-        
+
 0.0102
         Fix checkbox support to default_values (on as a value)
         Fix checkbox/remove support in general by issuing remove for undef values

--- a/lib/HTML/FormFu/Model/LDAP.pm
+++ b/lib/HTML/FormFu/Model/LDAP.pm
@@ -95,13 +95,13 @@ Example usage:
 
     # $ldap_entry should inherit from Net::LDAP::Entry, or atleast
     # implement get_value(), replace() and update()
-    
+
     # set form's default values from LDAP
-    
+
     $form->model->default_values($ldap_entry);
-    
+
     # update LDAP with values from submitted form
-    
+
     if ($form->submitted_and_valid) {
         $form->model->update($ldap_entry);
     }


### PR DESCRIPTION
Trailing whitespace is seen in some projects as bad practice (e.g. the Linux kernel) and is hence explicitly forbidden; other projects see its removal as plain nit-picking. This PR is submitted in the hope that it is helpful, however if you don't see any need to remove such whitespace I'm happy if you close the PR as unmerged.